### PR TITLE
Small refactorings

### DIFF
--- a/src/commands/change-default.ts
+++ b/src/commands/change-default.ts
@@ -53,7 +53,7 @@ export default class ChangeDefault extends APICommand {
       return
     }
 
-    const value = await getValue({desiredValue: flags.value, environment, flags, key, prefab, message: 'Default value'})
+    const value = await getValue({desiredValue: flags.value, environment, flags, key, message: 'Default value', prefab})
 
     if (value.ok) {
       return this.submitChange(prefab, key, value.value, environment)
@@ -66,13 +66,13 @@ export default class ChangeDefault extends APICommand {
     const type = configValueType(key)
 
     if (!type) {
-      return this.errorForCurrentFormat(`no type found for ${key}`)
+      return this.err(`no type found for ${key}`)
     }
 
     const config = prefab.raw(key)
 
     if (!config) {
-      return this.errorForCurrentFormat(`no config found for ${key}`)
+      return this.err(`no config found for ${key}`)
     }
 
     const payload = {
@@ -84,18 +84,14 @@ export default class ChangeDefault extends APICommand {
 
     const request = await this.apiClient.post('/api/v1/config/set-default/', payload)
 
-    if (request.success) {
+    if (request.ok) {
       this.log(`Successfully changed default to \`${value}\`.`)
 
       return {environment, key, success: true, value}
     }
 
-    if (this.jsonEnabled()) {
-      throw {key, serverError: request.error}
-    }
-
     this.verboseLog(request.error)
 
-    this.error(`Failed to change default: ${request.status}`)
+    this.err(`Failed to change default: ${request.status}`, {key, serverError: request.error})
   }
 }

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -33,11 +33,11 @@ export default class Create extends APICommand {
     if (recipeRequest.status !== 200) {
       const error = jsonMaybe(await recipeRequest.text())
 
-      if (this.jsonEnabled()) {
-        throw {key, phase: 'recipe', serverError: error}
-      }
-
-      this.error(`Failed to create boolean flag recipe: ${recipeRequest.status} | ${error}`)
+      this.err(`Failed to create boolean flag recipe: ${recipeRequest.status} | ${error}`, {
+        key,
+        phase: 'recipe',
+        serverError: error,
+      })
     }
 
     const payload = (await recipeRequest.json()) as Record<string, unknown>
@@ -47,23 +47,18 @@ export default class Create extends APICommand {
     if (request.status !== 200) {
       const error = jsonMaybe(await request.text())
 
-      if (this.jsonEnabled()) {
-        throw {key, phase: 'creation', serverError: error}
-      }
+      const errMsg =
+        request.status === 409
+          ? `Failed to create boolean flag: ${key} already exists`
+          : `Failed to create boolean flag: ${request.status} | ${JSON.stringify(error)}`
 
-      if (request.status === 409) {
-        this.error(`Failed to create boolean flag: ${key} already exists`)
-      } else {
-        this.error(`Failed to create boolean flag: ${request.status} | ${JSON.stringify(error)}`)
-      }
+      this.err(errMsg, {key, phase: 'creation', serverError: error})
     }
 
     const response = await request.json()
 
-    if (this.jsonEnabled()) {
-      return {key, ...response}
-    }
-
     this.log(`Created boolean flag: ${key}`)
+
+    return {key, ...response}
   }
 }

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -22,7 +22,7 @@ export default class Get extends APICommand {
 
     if (key && prefab) {
       if (!prefab.keys().includes(key)) {
-        this.errorForCurrentFormat(`${key} does not exist`)
+        this.err(`${key} does not exist`)
       }
 
       const value = prefab.get(key)

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -31,7 +31,7 @@ export default class Info extends APICommand {
       })
 
       if (!evaluations) {
-        return this.errorForCurrentFormat(`No evaluations found for ${key} in the past 24 hours`)
+        return this.err(`No evaluations found for ${key} in the past 24 hours`)
       }
 
       this.log('Evaluations over the last 24 hours:\n')

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -47,9 +47,7 @@ export default class List extends APICommand {
       keys = keys.filter((key) => types.includes(prefab.raw(key)!.configType))
     }
 
-    if (!this.jsonEnabled()) {
-      this.log(keys.join('\n'))
-    }
+    this.log(keys.join('\n'))
 
     return {keys}
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,9 @@ export abstract class BaseCommand extends Command {
 
   public static enableJsonFlag = true
 
-  public errorForCurrentFormat = (error: Error | object | string): never => {
+  public err = (error: Error | object | string, json?: Record<string, unknown>): never => {
     if (this.jsonEnabled()) {
-      throw error
+      throw json ?? error
     }
 
     if (typeof error === 'string') {
@@ -38,7 +38,7 @@ export abstract class BaseCommand extends Command {
 
   public resultMessage = (result: Result<unknown>): void => {
     if (result.error) {
-      this.errorForCurrentFormat(result.message)
+      this.err(result.message, result.json)
     } else if (result.message) {
       this.log(result.message)
     }

--- a/src/pickers/get-environment.ts
+++ b/src/pickers/get-environment.ts
@@ -21,7 +21,7 @@ const getEnvironment = async ({
   providedEnvironment: string | undefined
 }): Promise<Environment | undefined> => {
   if (!providedEnvironment && !isInteractive(flags)) {
-    command.errorForCurrentFormat("'environment' is required when interactive mode isn't available.")
+    command.err("'environment' is required when interactive mode isn't available.")
   }
 
   const environments = await getEnvironmentsFromApi({client, log})
@@ -34,7 +34,7 @@ const getEnvironment = async ({
     )
 
     if (!matchingEnvironment) {
-      command.errorForCurrentFormat(`Environment \`${providedEnvironment}\` not found`)
+      command.err(`Environment \`${providedEnvironment}\` not found`)
     }
 
     return matchingEnvironment

--- a/src/pickers/get-key.ts
+++ b/src/pickers/get-key.ts
@@ -17,7 +17,7 @@ const getKey = async ({
   message: string
 }): Promise<{key: string | undefined; prefab: Prefab | undefined}> => {
   if (!args.name && !isInteractive(flags)) {
-    command.errorForCurrentFormat("'name' argument is required when interactive mode isn't available.")
+    command.err("'name' argument is required when interactive mode isn't available.")
   }
 
   const prefab = await initPrefab(command, flags)

--- a/src/pickers/get-value.ts
+++ b/src/pickers/get-value.ts
@@ -15,15 +15,15 @@ const getValue = async ({
   environment,
   flags,
   key,
-  prefab,
   message,
+  prefab,
 }: {
   desiredValue: string | undefined
   environment?: Environment
   flags: {interactive: boolean}
   key: string
-  prefab: Prefab
   message: string
+  prefab: Prefab
 }): Promise<Result<string>> => {
   if (desiredValue === undefined && !flags.interactive) {
     return failure(`No value provided for ${key}`)

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,37 +1,66 @@
-type Json = Record<string, unknown>
+// The goal of the Result approach is to allow writing code like this:
+//
+//  const result = await doSomething()
+//
+//  if (result.ok) {
+//    // do something with result.value
+//    // maybe show the `message` or `json` if they are set
+//  } else {
+//    this.resultMessage(result)
+//  }
+//
+// The resultMessage method will print the message if the result is a Failure
+// but a Noop might not have a message.
+//
+// If `json` is set and JSON is enabled, it will be preferred to the `message`
+export type Result<T> = Failure | Noop | Success<T>
+
+export type JsonObj = Record<string, unknown>
 
 export type Noop = {
   error: false
-  json?: Json
+  json?: JsonObj
   message?: string
   ok: false
 }
 
 export type Failure = {
   error: true
-  json?: Json
+  json?: JsonObj
   message: string
   ok: false
 }
 
 export type Success<T> = {
   error: false
-  json?: Json
+  json?: JsonObj
   message?: string
   ok: true
   value: T
 }
 
-export type Result<T> = Failure | Noop | Success<T>
-
 export const noop = (message?: string): Noop => ({error: false, message, ok: false})
 
-export const failure = (message: string, json?: Json): Failure => ({error: true, json, message, ok: false})
+export const failure = (message: string, json?: JsonObj): Failure => ({error: true, json, message, ok: false})
 
-export const success = <T>(value: T, message?: string, json?: Json): Success<T> => ({
+export const success = <T>(value: T, message?: string, json?: JsonObj): Success<T> => ({
   error: false,
   json,
   message,
   ok: true,
   value,
 })
+
+export type RequestSuccess = {
+  json: JsonObj | string
+  ok: true
+  status: number
+}
+
+export type RequestFailure = {
+  error: JsonObj | string
+  ok: false
+  status: number
+}
+
+export type RequestResult = RequestFailure | RequestSuccess

--- a/src/util/get-client.ts
+++ b/src/util/get-client.ts
@@ -1,3 +1,5 @@
+import type {RequestResult} from '../result.js'
+
 import {Client} from '../prefab-common/src/api/client.js'
 import jsonMaybe from '../util/json-maybe.js'
 import version from '../version.js'
@@ -18,21 +20,19 @@ const getClient = (apiKey: string) => {
   return clientInstance
 }
 
-type Json = Record<string, unknown> & {success: boolean}
-
-export const unwrapRequest = async (promise: Promise<Response>) => {
+export const unwrapRequest = async (promise: Promise<Response>): Promise<RequestResult> => {
   const request = await promise
 
   if (request.status.toString().startsWith('2')) {
     const json = await request.json()
     log('ApiClient', {response: json})
 
-    return {success: true, ...json} as Json
+    return {json, ok: true, status: request.status}
   }
 
   const error = jsonMaybe(await request.text())
 
-  return {error, status: request.status, success: false}
+  return {error, ok: false, status: request.status}
 }
 
 export default getClient

--- a/src/util/json-maybe.ts
+++ b/src/util/json-maybe.ts
@@ -1,6 +1,9 @@
 // Sometimes we get JSON from the server but if there's an exception, we might get a string.
 // This function will try to parse the string as JSON and return the parsed object or the original string.
-const jsonMaybe = (json: object | string) => {
+
+import type {JsonObj} from '../result.js'
+
+const jsonMaybe = (json: JsonObj | string): JsonObj | string => {
   if (typeof json === 'string') {
     try {
       return JSON.parse(json)

--- a/test/test-helper.ts
+++ b/test/test-helper.ts
@@ -1,13 +1,15 @@
 import {DefaultBodyType, HttpResponse, StrictRequest} from 'msw'
 
-type Json = Record<string, unknown>
-export type CannedResponse = [Json, Json, number]
+import type {JsonObj} from '../src/result.js'
+
+export type CannedResponse = [JsonObj, JsonObj, number]
 export type CannedResponses = Record<string, CannedResponse[]>
 
 // NOTE: This is a bit brittle in that it can break if currentVersionId changes
 // We can cross that bridge when we get there (possibly by iterating over the
 // object and comparing keys/values and having a special ANY or NUMBER
-// placeholder)
+// placeholder. Alternatively we could just ignore currentVersionId
+// specifically)
 export const getCannedResponse = async (
   request: StrictRequest<DefaultBodyType>,
   cannedResponses: CannedResponses,


### PR DESCRIPTION
- errorForCurrentFormat -> err
- use `err` consistently
- document Result
- use Result-like for http results
