### PR TITLE
Add `create --env-var` to interactive prompt

### DIFF
--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -8,7 +8,7 @@ import {initPrefab} from '../prefab.js'
 import {ConfigType, ConfigValue, ConfigValueType, NewConfig} from '../prefab-common/src/types.js'
 import {JsonObj} from '../result.js'
 import getValue from '../ui/get-value.js'
-import {coerceBool, coerceIntoType} from '../util/coerce.js'
+import {TYPE_MAPPING, coerceBool, coerceIntoType} from '../util/coerce.js'
 import {checkmark} from '../util/color.js'
 import secretFlags, {makeConfidentialValue, parsedSecretFlags} from '../util/secret-flags.js'
 
@@ -68,7 +68,7 @@ export default class Create extends APICommand {
     }
 
     let configValue: ConfigValue = {}
-    let valueType: ConfigValueType = ConfigValueType.STRING
+    let valueType: ConfigValueType = TYPE_MAPPING[flags.type]
 
     if (flags['env-var']) {
       configValue = {

--- a/src/interactive-prompt.ts
+++ b/src/interactive-prompt.ts
@@ -74,6 +74,13 @@ commands.push(
     id: 'create',
     implicitFlags: ['secret'],
   },
+  {
+    command: Create,
+    description: 'Create an ENV Var provided item in Prefab with --env-var',
+    displayCommandName: 'create --env-var',
+    id: 'create',
+    implicitFlags: ['env-var'],
+  },
 )
 
 type AvailableCommand = (typeof commands)[number]
@@ -166,12 +173,9 @@ const getFlags = async (
       if (arg.type === 'boolean') {
         inputs.push(`--${key}`)
       } else {
-        const inputPromise = async () => {
-          const value = await promptForInput(arg, key, commandId, apiKey)
-          inputs.push(`--${key}=${value}`)
-        }
-
-        promiseInputs.push(inputPromise())
+        // eslint-disable-next-line no-await-in-loop
+        const value = await promptForInput(arg, key, commandId, apiKey)
+        inputs.push(`--${key}=${value}`)
       }
     }
   }

--- a/src/util/coerce.ts
+++ b/src/util/coerce.ts
@@ -8,10 +8,20 @@ const BOOLEAN_VALUES = new Set([...TRUE_VALUES, 'false', '0', 'f'])
 
 type ConfigValueWithConfigValueType = [ConfigValue, ConfigValueType]
 
+export const TYPE_MAPPING: Record<string, ConfigValueType> = {
+  bool: ConfigValueType.BOOL,
+  boolean: ConfigValueType.BOOL,
+  double: ConfigValueType.DOUBLE,
+  int: ConfigValueType.INT,
+  string: ConfigValueType.STRING,
+  'string-list': ConfigValueType.STRING_LIST,
+  stringList: ConfigValueType.STRING_LIST,
+}
+
 export const coerceIntoType = (type: string, value: string): ConfigValueWithConfigValueType | undefined => {
   switch (type) {
     case 'string': {
-      return [{string: value}, ConfigValueType.STRING]
+      return [{string: value}, TYPE_MAPPING[type]]
     }
 
     case 'int': {
@@ -22,7 +32,7 @@ export const coerceIntoType = (type: string, value: string): ConfigValueWithConf
       }
 
       // This unknown as Long is annoying but Long doesn't serialize to JSON correctly ATM
-      return [{int: int as unknown as Long}, ConfigValueType.INT]
+      return [{int: int as unknown as Long}, TYPE_MAPPING[type]]
     }
 
     case 'double': {
@@ -32,17 +42,17 @@ export const coerceIntoType = (type: string, value: string): ConfigValueWithConf
         throw new TypeError(`Invalid default value for double: ${value}`)
       }
 
-      return [{double}, ConfigValueType.DOUBLE]
+      return [{double}, TYPE_MAPPING[type]]
     }
 
     case 'bool':
     case 'boolean': {
-      return [{bool: coerceBool(value)}, ConfigValueType.BOOL]
+      return [{bool: coerceBool(value)}, TYPE_MAPPING[type]]
     }
 
     case 'stringList':
     case 'string-list': {
-      return [{stringList: {values: value.split(/\s*,\s*/)}}, ConfigValueType.STRING_LIST]
+      return [{stringList: {values: value.split(/\s*,\s*/)}}, TYPE_MAPPING[type]]
     }
 
     default: {

--- a/test/commands/create.test.ts
+++ b/test/commands/create.test.ts
@@ -119,6 +119,13 @@ describe('create', () => {
         expect(error.message).to.contain(`Invalid default value for int: hat`)
       })
       .it('returns an error if the value is not an int')
+
+    test
+      .stdout()
+      .command(['create', 'int.from.env', '--type=int', '--env-var=MY_INT'])
+      .it('can create an int provided by an env var', (ctx) => {
+        expect(ctx.stdout).to.contain(`Created config: int.from.env`)
+      })
   })
 
   describe('type=double', () => {

--- a/test/responses/create.ts
+++ b/test/responses/create.ts
@@ -111,6 +111,14 @@ const cannedResponses: CannedResponses = {
       200,
     ],
     [
+      createRequest('int.from.env', {
+        rows: [{properties: {}, values: [{criteria: [], value: {provided: {lookup: 'MY_INT', source: 1}}}]}],
+        valueType: 1,
+      }),
+      successResponse,
+      200,
+    ],
+    [
       createRequest('greeting.from.env', {
         rows: [{properties: {}, values: [{criteria: [], value: {provided: {lookup: 'GREETING', source: 1}}}]}],
       }),


### PR DESCRIPTION
Also add a test for env vars of type `int`
