### PR TITLE
Fix: default `--help`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "bin": "prefab",
     "dirname": "prefab",
     "commands": "./dist/commands",
-    "default": "interactive",
     "plugins": [],
     "topicSeparator": " ",
     "helpClass": "./dist/help"


### PR DESCRIPTION
This was broken by `interactive` being the default.

I don't think we lose anything with this change.
