### PR TITLE
Use api-endpoint directly

### DIFF
--- a/src/prefab.ts
+++ b/src/prefab.ts
@@ -38,7 +38,7 @@ export const initPrefab = async (_ctx: CommandLike, flagsOrDatafile: FlagsOrData
     enableSSE: false,
   }
 
-  if (process.env.PREFAB_API_URL) options.sources = [process.env.PREFAB_API_URL]
+  options.sources = process.env.PREFAB_API_URL ? [process.env.PREFAB_API_URL] : ['https://api.prefab.cloud']
 
   prefab = new Prefab(options)
 


### PR DESCRIPTION
If you're running commands in batch (e.g. to migrate configs/flags into
prefab), it is possible to hit a race-condition where the belt is
temporarily outdated pending a purge from your previous command. In this
case you can submit an outdated `currentVersionId` and get a
409/conflict response.

Hitting the api directly prevents this race condition.
