### PR TITLE
CamelCase all method names

### DIFF
--- a/test/codegen/zod-generator.test.ts
+++ b/test/codegen/zod-generator.test.ts
@@ -142,7 +142,7 @@ describe('ZodGenerator', () => {
 
       expect(schemaLines).to.have.lengthOf(4)
       expect(schemaLines[0].key).to.equal('example.feature.flag')
-      expect(schemaLines[0].schemaName).to.equal('example_feature_flagSchema')
+      expect(schemaLines[0].schemaName).to.equal('exampleFeatureFlagSchema')
     })
   })
 
@@ -151,7 +151,7 @@ describe('ZodGenerator', () => {
       const generator = new ZodGenerator(mockConfigFile)
       const accessorMethod = generator.generateAccessorMethod(mockBoolConfig, SupportedLanguage.TypeScript)
 
-      expect(accessorMethod.methodName).to.equal('example_feature_flag')
+      expect(accessorMethod.methodName).to.equal('exampleFeatureFlag')
       expect(accessorMethod.key).to.equal('example.feature.flag')
       expect(accessorMethod.isFunctionReturn).to.be.false
       expect(accessorMethod.returnType).to.equal('boolean')
@@ -162,7 +162,7 @@ describe('ZodGenerator', () => {
       const generator = new ZodGenerator(mockConfigFile)
       const accessorMethod = generator.generateAccessorMethod(mockStringConfig, SupportedLanguage.TypeScript)
 
-      expect(accessorMethod.methodName).to.equal('example_config_string')
+      expect(accessorMethod.methodName).to.equal('exampleConfigString')
       expect(accessorMethod.key).to.equal('example.config.string')
       expect(accessorMethod.isFunctionReturn).to.be.false
       expect(accessorMethod.returnType).to.equal('string')
@@ -173,7 +173,7 @@ describe('ZodGenerator', () => {
       const generator = new ZodGenerator(mockConfigFile)
       const accessorMethod = generator.generateAccessorMethod(mockTemplateConfig, SupportedLanguage.TypeScript)
 
-      expect(accessorMethod.methodName).to.equal('example_config_function')
+      expect(accessorMethod.methodName).to.equal('exampleConfigFunction')
       expect(accessorMethod.key).to.equal('example.config.function')
       expect(accessorMethod.isFunctionReturn).to.be.true
       expect(accessorMethod.returnType).to.equal('string')
@@ -188,7 +188,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockBoolConfig)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `example_feature_flag(contexts?: Contexts | ContextObj): boolean {
+      const expectedOutput = `exampleFeatureFlag(contexts?: Contexts | ContextObj): boolean {
   const raw = this.get('example.feature.flag', contexts);
   return raw;
 }`
@@ -202,7 +202,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockTemplateConfig)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `example_config_function(contexts?: Contexts | ContextObj): (params: { name: string }) => string {
+      const expectedOutput = `exampleConfigFunction(contexts?: Contexts | ContextObj): (params: { name: string }) => string {
   const raw = this.get('example.config.function', contexts);
   return (params: { name: string }) => Mustache.render(raw, params);
 }`
@@ -216,7 +216,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectConfig)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `example_config_object(contexts?: Contexts | ContextObj): { name: string; age: number } {
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { name: string; age: number } {
   const raw = this.get('example.config.object', contexts);
   return { "name": raw["name"], "age": raw["age"] };
 }`
@@ -259,7 +259,7 @@ describe('ZodGenerator', () => {
       const accessorMethod = generator.renderAccessorMethod(complexConfig)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `example_greeting_template(contexts?: Contexts | ContextObj): (params: { name: string; company: string; user.id: string }) => string {
+      const expectedOutput = `exampleGreetingTemplate(contexts?: Contexts | ContextObj): (params: { name: string; company: string; user.id: string }) => string {
   const raw = this.get('example.greeting.template', contexts);
   return (params: { name: string; company: string; user.id: string }) => Mustache.render(raw, params);
 }`
@@ -275,7 +275,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockBoolConfig, SupportedLanguage.Python)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `def example_feature_flag(self):
+      const expectedOutput = `def exampleFeatureFlag(self):
       raw = self.get('example.feature.flag')
       return raw`
 
@@ -287,7 +287,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockTemplateConfig, SupportedLanguage.Python)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `def example_config_function(self):
+      const expectedOutput = `def exampleConfigFunction(self):
       raw = self.get('example.config.function')
       return lambda params: pystache.render(raw, params)`
 
@@ -299,7 +299,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectConfig, SupportedLanguage.Python)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `def example_config_object(self):
+      const expectedOutput = `def exampleConfigObject(self):
       raw = self.get('example.config.object')
       return { "name": raw["name"], "age": raw["age"] }`
 
@@ -314,7 +314,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfig)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `example_config_object(contexts?: Contexts | ContextObj): { template: (params: { placeholder: string }) => string } {
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: (params: { placeholder: string }) => string } {
   const raw = this.get('example.config.object', contexts);
   return { "template": (params: { placeholder: string }) => Mustache.render(raw["template"], params) };
 }`
@@ -328,7 +328,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfigMultiValue)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `example_config_object(contexts?: Contexts | ContextObj): { template: ((params: { other_placeholder: string }) => string) | ((params: { placeholder: string }) => string); num: any } {
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: ((params: { other_placeholder: string }) => string) | ((params: { placeholder: string }) => string); num: any } {
   const raw = this.get('example.config.object', contexts);
   return { "template": (params: { other_placeholder: string }) => Mustache.render(raw["template"], params), "num": raw["num"] };
 }`
@@ -344,7 +344,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfig, SupportedLanguage.Python)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `def example_config_object(self):
+      const expectedOutput = `def exampleConfigObject(self):
       raw = self.get('example.config.object')
       return { "template": lambda params: pystache.render(raw["template"], params) }`
 
@@ -357,7 +357,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfigMultiValue, SupportedLanguage.Python)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `def example_config_object(self):
+      const expectedOutput = `def exampleConfigObject(self):
       raw = self.get('example.config.object')
       return { "template": lambda params: pystache.render(raw["template"], params), "num": raw["num"] }`
 

--- a/test/codegen/zod-utils.test.ts
+++ b/test/codegen/zod-utils.test.ts
@@ -1,8 +1,6 @@
 import {expect} from '@oclif/test'
 import {z} from 'zod'
 
-import type {Config} from '../../src/codegen/types.js'
-
 import {SupportedLanguage} from '../../src/codegen/zod-generator.js'
 import {ZodUtils} from '../../src/codegen/zod-utils.js'
 
@@ -84,8 +82,8 @@ describe('ZodUtils', () => {
     })
 
     it('should convert dotted keys to method names', () => {
-      expect(ZodUtils.keyToMethodName('user.profile')).to.equal('user_profile')
-      expect(ZodUtils.keyToMethodName('app.settings.theme')).to.equal('app_settings_theme')
+      expect(ZodUtils.keyToMethodName('user.profile')).to.equal('userProfile')
+      expect(ZodUtils.keyToMethodName('app.settings.theme')).to.equal('appSettingsTheme')
     })
 
     it('should ensure method names are valid identifiers', () => {
@@ -93,23 +91,23 @@ describe('ZodUtils', () => {
       expect(ZodUtils.keyToMethodName('test-key')).to.equal('testKey')
     })
     it('should convert simple keys', () => {
-      expect(ZodUtils.keyToMethodName('flag.tidelift')).to.equal('flag_tidelift')
-      expect(ZodUtils.keyToMethodName('simple.config')).to.equal('simple_config')
+      expect(ZodUtils.keyToMethodName('flag.tidelift')).to.equal('flagTidelift')
+      expect(ZodUtils.keyToMethodName('simple.config')).to.equal('simpleConfig')
     })
 
     it('should handle hyphens', () => {
-      expect(ZodUtils.keyToMethodName('flag.tide-lift')).to.equal('flag_tideLift')
-      expect(ZodUtils.keyToMethodName('multi-word.key-name')).to.equal('multiWord_keyName')
+      expect(ZodUtils.keyToMethodName('flag.tide-lift')).to.equal('flagTideLift')
+      expect(ZodUtils.keyToMethodName('multi-word.key-name')).to.equal('multiWordKeyName')
     })
 
     it('should properly camelCase parts after the first one', () => {
-      expect(ZodUtils.keyToMethodName('first.second')).to.equal('first_second')
-      expect(ZodUtils.keyToMethodName('module.feature.enabled')).to.equal('module_feature_enabled')
+      expect(ZodUtils.keyToMethodName('first.second')).to.equal('firstSecond')
+      expect(ZodUtils.keyToMethodName('module.feature.enabled')).to.equal('moduleFeatureEnabled')
     })
 
     it('should deal with spaces', () => {
-      expect(ZodUtils.keyToMethodName('first second')).to.equal('first_second')
-      expect(ZodUtils.keyToMethodName('module feature.is-enabled')).to.equal('module_feature_isEnabled')
+      expect(ZodUtils.keyToMethodName('first second')).to.equal('firstSecond')
+      expect(ZodUtils.keyToMethodName('module feature.is-enabled')).to.equal('moduleFeatureIsEnabled')
     })
 
     it('should handle complex keys with special characters', () => {
@@ -119,15 +117,15 @@ describe('ZodUtils', () => {
       // 3. Normalizing consecutive dots: '_234nas6234._.WHY_OH_WHY'
       // 4. Splitting by dots: ['_234nas6234', '_', 'WHY_OH_WHY']
       // 5. Camel-casing parts: ['_234nas6234', '_', 'whyOhWhy']
-      // 6. Joining with underscores: '_234nas6234__whyOhWhy'
-      expect(ZodUtils.keyToMethodName('234nas6234^&#$__///WHY_OH_WHY')).to.equal('_234nas6234__whyOhWhy')
+      // 6. Joining with camelCase: '_234nas6234WhyOhWhy'
+      expect(ZodUtils.keyToMethodName('234nas6234^&#$__///WHY_OH_WHY')).to.equal('_234nas6234WhyOhWhy')
     })
   })
 
   describe('keyToSchemaName', () => {
     it('should convert keys to schema variable names', () => {
       expect(ZodUtils.keyToSchemaName('test')).to.equal('testSchema')
-      expect(ZodUtils.keyToSchemaName('app.settings')).to.equal('app_settingsSchema')
+      expect(ZodUtils.keyToSchemaName('app.settings')).to.equal('appSettingsSchema')
     })
   })
 


### PR DESCRIPTION
This avoids typescript names being underscore-based (or a mix of camelCase and underscore-based)

It looks like python is still good AFAICT. Comparing the output before and after, the only diff is

```diff
<     def experiments_exp32_new_checkout_flow(self, context: Optional[Union[dict, Context]] = None, default: Optional[str] = None) -> str:
---
>     def experiments_exp_32_new_checkout_flow(self, context: Optional[Union[dict, Context]] = None, default: Optional[str] = None) -> str:
```