### PR TITLE
Update UnifiedPythonGenerator to preserve original field names for Py…

### DIFF
--- a/src/codegen/python/pydantic-generator.ts
+++ b/src/codegen/python/pydantic-generator.ts
@@ -511,8 +511,12 @@ export class UnifiedPythonGenerator {
       for (const [fieldName, fieldSchema] of Object.entries(shape)) {
         if (isZodType(fieldSchema)) {
           const fieldType = this.getPydanticType(fieldSchema)
-          // Convert field name directly to Python snake_case
-          const pythonFieldName = this.toPythonMethodName(fieldName)
+
+          // IMPORTANT: For Pystache template parameters, we must preserve the exact
+          // field names for the template to work properly.
+          // Do NOT convert the field names to snake_case or any other format.
+          const pythonFieldName = fieldName
+
           fields.push({name: pythonFieldName, type: fieldType})
         }
       }

--- a/test/codegen/python/pydantic-generator.test.ts
+++ b/test/codegen/python/pydantic-generator.test.ts
@@ -471,8 +471,8 @@ describe('UnifiedPythonGenerator', () => {
       const paramClass = (generator as any).paramClasses.get(className)
       expect(paramClass).to.exist
 
-      // Check that parameters were converted to snake_case
-      expect(paramClass.fields[0]).to.deep.include({name: 'user_id', type: 'int'})
+      // Check that parameters preserve their exact original names for mustache templates
+      expect(paramClass.fields[0]).to.deep.include({name: 'userId', type: 'int'})
       expect(paramClass.fields[1]).to.deep.include({name: 'status', type: 'str'})
     })
 


### PR DESCRIPTION
…stache templates

- Modified the field name handling in UnifiedPythonGenerator to retain the original names instead of converting them to snake_case, ensuring compatibility with Pystache template parameters.
- Updated tests to reflect this change, verifying that field names are now preserved as camelCase.