### PR TITLE
Throw if method names conflict

### DIFF
--- a/src/codegen/python/pydantic-generator.ts
+++ b/src/codegen/python/pydantic-generator.ts
@@ -481,6 +481,12 @@ export class UnifiedPythonGenerator {
       this.imports.addStandardImport('pystache')
     }
 
+    if (this.methods.get(pythonMethodName)) {
+      throw new Error(
+        `Method '${pythonMethodName}' is already registered. Prefab key ${methodName} conflicts with ${this.methods.get(pythonMethodName)?.originalKey}`,
+      )
+    }
+
     // Store the method spec with the original key
     this.methods.set(pythonMethodName, {
       returnType,

--- a/src/codegen/zod-generator.ts
+++ b/src/codegen/zod-generator.ts
@@ -46,6 +46,7 @@ export interface TemplateData {
 export class ZodGenerator {
   private configFile: ConfigFile
   private schemaInferrer: SchemaInferrer
+  private methods: {[key: string]: AccessorMethod} = {}
 
   constructor(configFile: ConfigFile) {
     this.configFile = configFile
@@ -114,7 +115,7 @@ export class ZodGenerator {
       ? ZodUtils.zodTypeToTypescript(schemaObj._def.returns)
       : ZodUtils.zodTypeToTypescript(schemaObj)
 
-    return {
+    const accessorMethod = {
       isFunctionReturn: isFunction,
       key: config.key,
       methodName: ZodUtils.keyToMethodName(config.key),
@@ -123,6 +124,16 @@ export class ZodGenerator {
       returnType,
       returnValue,
     }
+
+    if (this.methods[accessorMethod.methodName]) {
+      throw new Error(
+        `Method '${accessorMethod.methodName}' is already registered. Prefab key ${config.key} conflicts with ${this.methods[accessorMethod.methodName].key}`,
+      )
+    }
+
+    this.methods[accessorMethod.methodName] = accessorMethod
+
+    return accessorMethod
   }
 
   /**

--- a/test/codegen/zod-generator.test.ts
+++ b/test/codegen/zod-generator.test.ts
@@ -135,6 +135,42 @@ describe('ZodGenerator', () => {
     }
   })
 
+  describe('generate', () => {
+    it('should generate a output for configs', () => {
+      const generator = new ZodGenerator(mockConfigFile)
+      const output = generator.generate(SupportedLanguage.TypeScript)
+
+      expect(output).to.include('PrefabConfig')
+    })
+
+    it('should throw if method names conflict', () => {
+      mockConfigFile.configs = [
+        ...mockConfigFile.configs,
+        {
+          configType: 'FEATURE_FLAG',
+          key: 'example-feature-flag',
+          rows: [
+            {
+              values: [
+                {
+                  value: {
+                    bool: true,
+                  },
+                },
+              ],
+            },
+          ],
+          valueType: 'BOOL',
+        },
+      ]
+      const generator = new ZodGenerator(mockConfigFile)
+
+      expect(() => generator.generate(SupportedLanguage.TypeScript)).to.throw(
+        `Method 'exampleFeatureFlag' is already registered. Prefab key example-feature-flag conflicts with example.feature.flag`,
+      )
+    })
+  })
+
   describe('generateSchemaLines', () => {
     it('should generate schema lines for configs', () => {
       const generator = new ZodGenerator(mockConfigFile)


### PR DESCRIPTION
We'll handle this better later (perhaps at the API layer), but this at least prevents generating code the gives you unexpected results.