### PR TITLE
Better optional handling for typescript

### DIFF
--- a/src/codegen/python/generator.ts
+++ b/src/codegen/python/generator.ts
@@ -1,5 +1,6 @@
 import {SchemaInferrer} from '../schema-inferrer.js'
 import {type ConfigFile} from '../types.js'
+import {SupportedLanguage} from '../zod-generator.js'
 import {UnifiedPythonGenerator} from './pydantic-generator.js'
 
 export function generatePythonClientCode(
@@ -17,7 +18,7 @@ export function generatePythonClientCode(
     .filter((config) => config.rows.length > 0)
     // eslint-disable-next-line unicorn/no-array-for-each
     .forEach((config) => {
-      const inferredSchema = schemaInferrer.zodForConfig(config, configFile)
+      const {schema: inferredSchema} = schemaInferrer.zodForConfig(config, configFile, SupportedLanguage.Python)
       generator.registerMethod(
         config.key,
         inferredSchema,

--- a/src/codegen/templates/typescript-accessor.mustache
+++ b/src/codegen/templates/typescript-accessor.mustache
@@ -1,4 +1,4 @@
-{{methodName}}(contexts?: Contexts | ContextObj){{#isFunctionReturn}}{{#params}}: (params: {{params}}) => {{/params}}{{/isFunctionReturn}}{{^isFunctionReturn}}: {{/isFunctionReturn}}{{{returnType}}} {
-  const raw = this.get('{{key}}', contexts);
-  return {{{returnValue}}};
-} 
+  {{methodName}}(contexts?: Contexts | ContextObj){{#isFunctionReturn}}{{#params}}: (params: {{params}}) => {{/params}}{{/isFunctionReturn}}{{^isFunctionReturn}}: {{/isFunctionReturn}}{{{returnType}}} {
+    const raw = this.get('{{key}}', contexts);
+    return {{{returnValue}}};
+  }

--- a/src/codegen/templates/typescript-schema.mustache
+++ b/src/codegen/templates/typescript-schema.mustache
@@ -1,1 +1,1 @@
-"{{key}}": {{{zodType}}} 
+"{{key}}": {{{zodType}}}

--- a/src/codegen/templates/typescript.mustache
+++ b/src/codegen/templates/typescript.mustache
@@ -5,6 +5,41 @@ import { Prefab, Contexts } from "@prefab-cloud/prefab-cloud-node";
 import Mustache from 'mustache';
 type ContextObj = Record<string, Record<string, unknown>>;
 
+type ZodRawShape = Record<string, z.ZodTypeAny>;
+
+/**
+ * Creates a schema where all fields are optional but throw when accessing an undefined value.
+ * This ensures we can parse a partial object and access provided values. It will throw when
+ * missing values are accessed.
+ */
+function optionalRequiredAccess<T extends ZodRawShape>(shape: T) {
+  // Make all fields optional
+  const optionalShape: ZodRawShape = {};
+
+  for (const key in shape) {
+    optionalShape[key] = shape[key];
+  }
+
+  // Create the schema with optional fields and apply a proxy to throw when accessing a missing value
+  return z.object(optionalShape).transform(obj => {
+    return new Proxy(obj, {
+      get(target: Record<string | symbol, any>, prop: string | symbol) {
+        // Handle special symbols for JS runtime
+        if (typeof prop === 'symbol') {
+          return Reflect.get(target, prop);
+        }
+
+        // For regular string properties
+        if (prop in target && target[prop] !== undefined) {
+          return target[prop];
+        }
+
+        throw new Error(`Property ${String(prop)} is required but was not provided`);
+      }
+    });
+  });
+}
+
 // Generated parameter schemas for methods that use Mustache templates
 {{#accessorMethods}}
 {{#paramsSchema}}
@@ -26,5 +61,5 @@ export class PrefabTypesafe {
     return prefabSchema.shape[key].parse(value) as PrefabConfig[K];
   }
 
-  {{{accessorMethods}}}
+{{{accessorMethods}}}
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,2 +1,2 @@
 // NOTE: This file is generated
-export default '0.5.0-pre5'
+export default '0.5.0-pre6'

--- a/test/codegen/python/generator.test.ts
+++ b/test/codegen/python/generator.test.ts
@@ -3,6 +3,7 @@ import {expect} from 'chai'
 import {generatePythonClientCode} from '../../../src/codegen/python/generator.js'
 import {SchemaInferrer} from '../../../src/codegen/schema-inferrer.js'
 import {Config, ConfigFile} from '../../../src/codegen/types.js'
+import {SupportedLanguage} from '../../../src/codegen/zod-generator.js'
 
 describe('Python Generator Integration', () => {
   it('should generate Python code from config files', () => {
@@ -83,28 +84,35 @@ describe('Python Generator Integration', () => {
 
     // Mock SchemaInferrer - use a simple implementation that returns appropriate schemas
     const mockSchemaInferrer = {
-      zodForConfig(config: Config, _configFile: ConfigFile) {
+      zodForConfig(config: Config, _configFile: ConfigFile, _language: SupportedLanguage) {
         if (config.key === 'feature_enabled') {
-          return {_def: {typeName: 'ZodBoolean'}} // Mock boolean schema
+          return {providence: 'inferred', schema: {_def: {typeName: 'ZodBoolean'}}} // Mock boolean schema
         }
 
         if (config.key === 'api_url') {
-          return {_def: {typeName: 'ZodString'}} // Mock string schema
+          return {providence: 'inferred', schema: {_def: {typeName: 'ZodString'}}} // Mock string schema
         }
 
         if (config.key === 'timeout_seconds') {
-          return {_def: {checks: [{kind: 'int'}], typeName: 'ZodNumber'}} // Mock integer schema
+          return {providence: 'inferred', schema: {_def: {checks: [{kind: 'int'}], typeName: 'ZodNumber'}}} // Mock integer schema
         }
 
         if (config.key === 'rate_limits') {
-          return {_def: {typeName: 'ZodObject'}} // Mock object schema
+          return {providence: 'inferred', schema: {_def: {typeName: 'ZodObject'}}} // Mock object schema
         }
 
         if (config.key === 'allowed_origins') {
-          return {_def: {element: {_def: {typeName: 'ZodString'}}, typeName: 'ZodArray'}} // Mock string array schema
+          return {
+            providence: 'inferred',
+            schema: {_def: {element: {_def: {typeName: 'ZodString'}}, typeName: 'ZodArray'}},
+          } // Mock string array schema
         }
 
-        return {_def: {typeName: 'ZodUnknown'}}
+        if (config.key === 'feature.enabled') {
+          return {providence: 'inferred', schema: {_def: {checks: [{kind: 'int'}], typeName: 'ZodNumber'}}} // Mock integer schema
+        }
+
+        return {providence: 'inferred', schema: {_def: {typeName: 'ZodUnknown'}}}
       },
     } as unknown as SchemaInferrer
 
@@ -187,20 +195,20 @@ describe('Python Generator Integration', () => {
     }
 
     const mockSchemaInferrer = {
-      zodForConfig(config: Config, _configFile: ConfigFile) {
+      zodForConfig(config: Config, _configFile: ConfigFile, _language: SupportedLanguage) {
         if (config.key === 'feature_enabled') {
-          return {_def: {typeName: 'ZodBoolean'}} // Mock boolean schema
+          return {providence: 'inferred', schema: {_def: {typeName: 'ZodBoolean'}}} // Mock boolean schema
         }
 
         if (config.key === 'api_url') {
-          return {_def: {typeName: 'ZodString'}} // Mock string schema
+          return {providence: 'inferred', schema: {_def: {typeName: 'ZodString'}}} // Mock string schema
         }
 
         if (config.key === 'feature.enabled') {
-          return {_def: {checks: [{kind: 'int'}], typeName: 'ZodNumber'}} // Mock integer schema
+          return {providence: 'inferred', schema: {_def: {checks: [{kind: 'int'}], typeName: 'ZodNumber'}}} // Mock integer schema
         }
 
-        return {_def: {typeName: 'ZodUnknown'}}
+        return {providence: 'inferred', schema: {_def: {typeName: 'ZodUnknown'}}}
       },
     } as unknown as SchemaInferrer
 

--- a/test/codegen/zod-generator.test.ts
+++ b/test/codegen/zod-generator.test.ts
@@ -170,7 +170,7 @@ describe('ZodGenerator', () => {
       const generator = new ZodGenerator(mockConfigFile, logger)
 
       expect(() => generator.generate(SupportedLanguage.TypeScript)).to.throw(
-        `Method 'exampleFeatureFlag' is already registered. Prefab key example-feature-flag conflicts with example.feature.flag`,
+        `Method 'exampleFeatureFlag' is already registered. Prefab key example.feature.flag conflicts with example-feature-flag`,
       )
     })
   })
@@ -217,7 +217,7 @@ describe('ZodGenerator', () => {
       expect(accessorMethod.key).to.equal('example.config.function')
       expect(accessorMethod.isFunctionReturn).to.be.true
       expect(accessorMethod.returnType).to.equal('string')
-      expect(accessorMethod.returnValue).to.equal('(params: { name: string }) => Mustache.render(raw, params)')
+      expect(accessorMethod.returnValue).to.equal('(params: { name: string }) => Mustache.render(raw ?? "", params)')
       expect(accessorMethod.params).to.equal('{ name: string }')
     })
   })
@@ -229,9 +229,9 @@ describe('ZodGenerator', () => {
 
       // Use a single multiline string assertion for better readability
       const expectedOutput = `exampleFeatureFlag(contexts?: Contexts | ContextObj): boolean {
-  const raw = this.get('example.feature.flag', contexts);
-  return raw;
-}`
+    const raw = this.get('example.feature.flag', contexts);
+    return raw;
+  }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(result, expectedOutput)
@@ -243,9 +243,9 @@ describe('ZodGenerator', () => {
 
       // Use a single multiline string assertion for better readability
       const expectedOutput = `exampleConfigFunction(contexts?: Contexts | ContextObj): (params: { name: string }) => string {
-  const raw = this.get('example.config.function', contexts);
-  return (params: { name: string }) => Mustache.render(raw, params);
-}`
+    const raw = this.get('example.config.function', contexts);
+    return (params: { name: string }) => Mustache.render(raw ?? "", params);
+  }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(result, expectedOutput)
@@ -256,10 +256,10 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectConfig)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { name?: string; age?: number } {
-  const raw = this.get('example.config.object', contexts);
-  return { "name": raw["name"], "age": raw["age"] };
-}`
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { name: string; age: number } {
+    const raw = this.get('example.config.object', contexts);
+    return { "name": raw["name"], "age": raw["age"] };
+  }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(result, expectedOutput)
@@ -300,9 +300,9 @@ describe('ZodGenerator', () => {
 
       // Use a single multiline string assertion for better readability
       const expectedOutput = `exampleGreetingTemplate(contexts?: Contexts | ContextObj): (params: { name: string; company: string; user.id: string }) => string {
-  const raw = this.get('example.greeting.template', contexts);
-  return (params: { name: string; company: string; user.id: string }) => Mustache.render(raw, params);
-}`
+    const raw = this.get('example.greeting.template', contexts);
+    return (params: { name: string; company: string; user.id: string }) => Mustache.render(raw ?? "", params);
+  }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(accessorMethod, expectedOutput)
@@ -354,10 +354,10 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfig)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template?: (params: { placeholder: string }) => string } {
-  const raw = this.get('example.config.object', contexts);
-  return { "template": raw["template"] === undefined ? undefined : (params: { placeholder: string }) => Mustache.render(raw["template"], params) };
-}`
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: (params: { placeholder: string }) => string } {
+    const raw = this.get('example.config.object', contexts);
+    return { "template": (params: { placeholder: string }) => Mustache.render(raw["template"] ?? "", params) };
+  }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(result, expectedOutput)
@@ -368,10 +368,10 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfigMultiValue)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template?: (params: { other_placeholder?: string; placeholder?: string }) => string; num?: number } {
-  const raw = this.get('example.config.object', contexts);
-  return { "template": raw["template"] === undefined ? undefined : (params: { other_placeholder?: string; placeholder?: string }) => Mustache.render(raw["template"], params), "num": raw["num"] };
-}`
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: (params: { other_placeholder: string; placeholder: string }) => string; num: number } {
+    const raw = this.get('example.config.object', contexts);
+    return { "template": (params: { other_placeholder: string; placeholder: string }) => Mustache.render(raw["template"] ?? "", params), "num": raw["num"] };
+  }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(result, expectedOutput)
@@ -386,7 +386,7 @@ describe('ZodGenerator', () => {
       // Use a single multiline string assertion for better readability
       const expectedOutput = `def exampleConfigObject(self):
       raw = self.get('example.config.object')
-      return { "template": raw["template"] === undefined ? undefined : lambda params: pystache.render(raw["template"], params) }`
+      return { "template": lambda params: pystache.render(raw["template"], params) }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(result, expectedOutput)
@@ -399,7 +399,7 @@ describe('ZodGenerator', () => {
       // Use a single multiline string assertion for better readability
       const expectedOutput = `def exampleConfigObject(self):
       raw = self.get('example.config.object')
-      return { "template": raw["template"] === undefined ? undefined : lambda params: pystache.render(raw["template"], params), "num": raw["num"] }`
+      return { "template": lambda params: pystache.render(raw["template"], params), "num": raw["num"] }`
 
       // Normalize line endings before comparison
       expectToEqualWithNormalizedLineEndings(result, expectedOutput)


### PR DESCRIPTION
The original approach of using `?` meant that the end-user had to expect a value or an undefined everywhere. The ergonomics of that isn't what we want.

The original goal was to avoid a schema parsing failure if the original inferred schema was something like `{foo: number, bar: string}` and you passed `{"foo": 2}` (without bar). The ideal behavior is that the user can call `myConfig.foo` and get `2` but calling `myConfig.bar` would raise.

With this change, when we infer a schema, we parse it and ignore missing fields. For present fields, they return as expected. For missing fields, we throw on attempted access.

The user can always provide a strict schema to Prefab to avoid this sort of parsing.

We now pass around a SchemaWithProvidence which contains both the schema and whether it was inferred or user-provided. This allows us to treat inferred zod schemas differently (i.e. to allow for throwing on missing data).

We detect whether an array is homogeneous and a primitive. We treat non-homogeneous and object-y arrays as `z.array(z.unknown())`

Finally, I tweaked some whitespace for better output and sorted the keys/accessors.