### PR TITLE
Jd/optional params for mustache

### DIFF
--- a/src/codegen/schema-inferrer.ts
+++ b/src/codegen/schema-inferrer.ts
@@ -83,7 +83,8 @@ export class SchemaInferrer {
         mergedShape[key] = this.mergeTypes(typeA, typeB)
       } else {
         const existingType = typeA || typeB
-        mergedShape[key] = existingType
+        // Make the type optional if it exists in only one schema
+        mergedShape[key] = existingType.optional()
       }
     }
 

--- a/src/codegen/zod-utils.ts
+++ b/src/codegen/zod-utils.ts
@@ -10,8 +10,9 @@ export const ZodUtils = {
   generateParamsType(schemaShape: Record<string, z.ZodTypeAny>): string {
     const properties = Object.entries(schemaShape)
       .map(([key, type]) => {
-        const typeString = this.zodTypeToTsType(type)
-        return `${key}: ${typeString}`
+        const isOptional = type instanceof z.ZodOptional
+        const typeString = this.zodTypeToTsType(isOptional ? type._def.innerType : type)
+        return `${key}${isOptional ? '?' : ''}: ${typeString}`
       })
       .join('; ')
 

--- a/src/codegen/zod-utils.ts
+++ b/src/codegen/zod-utils.ts
@@ -531,7 +531,7 @@ export const ZodUtils = {
       }
 
       case 'ZodOptional': {
-        return `${this.zodTypeToTypescript(zodType._def.innerType)}`
+        return `${this.zodTypeToTypescript(zodType._def.innerType)}?`
       }
 
       case 'ZodNull': {
@@ -557,7 +557,7 @@ export const ZodUtils = {
             const typeStr = isOptional
               ? this.zodTypeToTypescript(propType._def.innerType)
               : this.zodTypeToTypescript(propType)
-            props.push(`${key}: ${typeStr}`)
+            props.push(`${key}${isOptional ? '?' : ''}: ${typeStr}`)
           }
         }
 

--- a/test/codegen/zod-generator.test.ts
+++ b/test/codegen/zod-generator.test.ts
@@ -368,7 +368,7 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfigMultiValue)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: (params: { other_placeholder?: string; placeholder?: string }) => string; num: number } {
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: (params: { other_placeholder?: string; placeholder?: string }) => string; num?: number } {
     const raw = this.get('example.config.object', contexts);
     return { "template": (params: { other_placeholder?: string; placeholder?: string }) => Mustache.render(raw["template"] ?? "", params), "num": raw["num"] };
   }`

--- a/test/codegen/zod-generator.test.ts
+++ b/test/codegen/zod-generator.test.ts
@@ -368,9 +368,9 @@ describe('ZodGenerator', () => {
       const result = generator.renderAccessorMethod(mockObjectWithPlaceholderConfigMultiValue)
 
       // Use a single multiline string assertion for better readability
-      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: (params: { other_placeholder: string; placeholder: string }) => string; num: number } {
+      const expectedOutput = `exampleConfigObject(contexts?: Contexts | ContextObj): { template: (params: { other_placeholder?: string; placeholder?: string }) => string; num: number } {
     const raw = this.get('example.config.object', contexts);
-    return { "template": (params: { other_placeholder: string; placeholder: string }) => Mustache.render(raw["template"] ?? "", params), "num": raw["num"] };
+    return { "template": (params: { other_placeholder?: string; placeholder?: string }) => Mustache.render(raw["template"] ?? "", params), "num": raw["num"] };
   }`
 
       // Normalize line endings before comparison

--- a/test/codegen/zod-utils.test.ts
+++ b/test/codegen/zod-utils.test.ts
@@ -503,4 +503,29 @@ describe('paramsOf', () => {
     expect(shape.name._def.typeName).to.equal('ZodString')
     expect(shape.age._def.typeName).to.equal('ZodNumber')
   })
+
+  it('should extract optional arguments schema from function schema', () => {
+    const argsSchema = z.object({name: z.string(), optional: z.string().optional()})
+    const fnSchema = z.function().args(argsSchema).returns(z.string())
+
+    const result = ZodUtils.paramsOf(fnSchema)
+    expect(result).to.equal(argsSchema)
+  })
+})
+
+describe('zodTypeToTypescript', () => {
+  it('should return the correct typescript type for a zod type', () => {
+    const result = ZodUtils.zodTypeToTypescript(z.string())
+    expect(result).to.equal('string')
+  })
+
+  it('should return the correct typescript type for an optional zod type', () => {
+    const result = ZodUtils.zodTypeToTypescript(z.string().optional())
+    expect(result).to.equal('string?')
+  })
+
+  it('should return the correct typescript type for an array of zod types', () => {
+    const result = ZodUtils.zodTypeToTypescript(z.object({age: z.number().optional(), name: z.string()}))
+    expect(result).to.equal('{ age?: number; name: string }')
+  })
 })

--- a/test/codegen/zod-utils.test.ts
+++ b/test/codegen/zod-utils.test.ts
@@ -94,7 +94,7 @@ describe('ZodUtils', () => {
         name: z.string(),
       }
       const result = ZodUtils.generateParamsType(schemaShape)
-      expect(result).to.equal('{ age: number; name: string }')
+      expect(result).to.equal('{ age?: number; name: string }')
     })
   })
 


### PR DESCRIPTION
For a config `my-config` with values of 
```json
{ "systemMessage": "a prompt"}
```
AND `when user.key IS 123`
```json
{ "systemMessage": "a prompt with {{placeholder}}"}
```

we generated 
```
  myConfig(contexts?: Contexts | ContextObj): { systemMessage: (params: { placeholder: string }) => string } {
    const raw = this.get('my-config', contexts);
    return { "systemMessage": (params: { productContext: string }) => Mustache.render(raw["systemMessage"] ?? "", params) };
  }
```

but this PR makes it generate
```
  myConfig(contexts?: Contexts | ContextObj): { systemMessage: (params: { placeholder?: string }) => string} {
    const raw = this.get('my-config', contexts);
    return { "systemMessage": (params: { placeholder?: string }) => Mustache.render(raw["systemMessage"] ?? "", params)};
  }
```

end user code can then call 
`myConfig().systemMessage({})` or `myConfig().systemMessage({productContext: "some context"})`

it's safe to add the product context in either case. if you end up with the variant with no placeholder, nothing will print. if you end up with the variant with a placeholder, but you didn't pass anything in, it will be empty. 
