### PR TITLE
Avoid redundant optionals

### DIFF
--- a/src/codegen/schema-inferrer.ts
+++ b/src/codegen/schema-inferrer.ts
@@ -84,7 +84,7 @@ export class SchemaInferrer {
       } else {
         const existingType = typeA || typeB
         // Make the type optional if it exists in only one schema
-        mergedShape[key] = existingType.optional()
+        mergedShape[key] = this.isOptional(existingType) ? existingType : existingType.optional()
       }
     }
 

--- a/test/codegen/schema-inferrer.test.ts
+++ b/test/codegen/schema-inferrer.test.ts
@@ -202,7 +202,11 @@ describe('SchemaInferrer', () => {
       const config: Config = {
         configType: 'CONFIG',
         key: 'test',
-        rows: [{values: [{value: {string: 'foo {{name}}'}}]}, {values: [{value: {string: 'bar {{baz}}'}}]}],
+        rows: [
+          {values: [{value: {string: 'foo {{name}}'}}]},
+          {values: [{value: {string: 'bar {{baz}}'}}]},
+          {values: [{value: {string: 'fizz {{buzz}}'}}]},
+        ],
         valueType: 'STRING',
       }
       const configFile: ConfigFile = {
@@ -211,7 +215,7 @@ describe('SchemaInferrer', () => {
 
       const {schema: result} = inferrer.zodForConfig(config, configFile, SupportedLanguage.Python)
       expect(ZodUtils.zodToString(result, 'test', 'inferred', SupportedLanguage.Python)).to.equal(
-        'z.function().args(z.object({name: z.string().optional(), baz: z.string().optional()})).returns(z.string())',
+        'z.function().args(z.object({name: z.string().optional(), baz: z.string().optional(), buzz: z.string().optional()})).returns(z.string())',
       )
     })
 


### PR DESCRIPTION
If something is already optional, we don't need to chain more optionals