### PR TITLE
Allow returning a `z.object` for homogeneous arrays

### DIFF
--- a/src/codegen/schema-inferrer.ts
+++ b/src/codegen/schema-inferrer.ts
@@ -24,13 +24,13 @@ export class SchemaInferrer {
         const firstItemType = typeof data[0]
         const isHomogeneous = data.every((item) => typeof item === firstItemType)
 
-        // For homogeneous arrays with non-object elements, use the first element's type
-        if (isHomogeneous && firstItemType !== 'object') {
+        // For homogeneous arrays, use the first element's type
+        if (isHomogeneous) {
           return z.array(this.jsonToInferredZod(data[0]))
         }
 
         // eslint-disable-next-line no-warning-comments
-        // TODO: we could handle mixed arrays here with a union type AND handle object types but we prefer the user to upload a schema
+        // TODO: we could handle mixed arrays here with a union type but we prefer the user to upload a schema
       }
 
       return z.array(z.unknown())

--- a/test/codegen/schema-inferrer.test.ts
+++ b/test/codegen/schema-inferrer.test.ts
@@ -189,12 +189,12 @@ describe('SchemaInferrer', () => {
       const {schema: result} = inferrer.zodForConfig(config, configFile, SupportedLanguage.TypeScript)
       expect(result._def.typeName).to.equal('ZodObject')
       expect(ZodUtils.zodToString(result, 'test', 'inferred', SupportedLanguage.TypeScript)).to.equal(
-        'optionalRequiredAccess({systemMessage: z.function().args(optionalRequiredAccess({user: z.array(optionalRequiredAccess({name: z.string()})), admin: z.array(optionalRequiredAccess({name: z.string()}))})).returns(z.string()), nested: optionalRequiredAccess({stuff: z.array(z.unknown())})})',
+        'optionalRequiredAccess({systemMessage: z.function().args(optionalRequiredAccess({user: z.array(z.object({name: z.string()})), admin: z.array(z.object({name: z.string()}))})).returns(z.string()), nested: optionalRequiredAccess({stuff: z.array(z.object({name: z.string()}))})})',
       )
 
       const {schema: resultPython} = inferrer.zodForConfig(config, configFile, SupportedLanguage.Python)
       expect(ZodUtils.zodToString(resultPython, 'test', 'inferred', SupportedLanguage.Python)).to.equal(
-        'z.object({systemMessage: z.function().args(z.object({user: z.array(z.object({name: z.string()})), admin: z.array(z.object({name: z.string()}))})).returns(z.string()), nested: z.object({stuff: z.array(z.unknown())})})',
+        'z.object({systemMessage: z.function().args(z.object({user: z.array(z.object({name: z.string()})), admin: z.array(z.object({name: z.string()}))})).returns(z.string()), nested: z.object({stuff: z.array(z.object({name: z.string()}))})})',
       )
     })
 
@@ -279,7 +279,7 @@ describe('SchemaInferrer', () => {
       const {schema: result} = inferrer.zodForConfig(config, configFile, SupportedLanguage.TypeScript)
       expect(result._def.typeName).to.equal('ZodObject')
       expect(ZodUtils.zodToString(result, 'test', 'inferred', SupportedLanguage.TypeScript)).to.equal(
-        'optionalRequiredAccess({systemMessage: z.function().args(optionalRequiredAccess({user: z.array(optionalRequiredAccess({name: z.string()})).optional(), admin: z.array(optionalRequiredAccess({name: z.string()})).optional(), placeholder: z.string().optional()})).returns(z.string()), nested: optionalRequiredAccess({stuff: z.array(z.unknown()).optional(), otherStuff: z.function().args(optionalRequiredAccess({placeholder2: z.string()})).returns(z.string()).optional()})})',
+        'optionalRequiredAccess({systemMessage: z.function().args(optionalRequiredAccess({user: z.array(z.object({name: z.string()})).optional(), admin: z.array(z.object({name: z.string()})).optional(), placeholder: z.string().optional()})).returns(z.string()), nested: optionalRequiredAccess({stuff: z.array(z.object({name: z.string()})).optional(), otherStuff: z.function().args(optionalRequiredAccess({placeholder2: z.string()})).returns(z.string()).optional()})})',
       )
     })
 


### PR DESCRIPTION
We avoid doing this if the object has an array parent anywhere in the chain as `optionalRequiredAccess` doesn't gracefully handle typing for those objects yet.